### PR TITLE
Fixed problems with 3djs

### DIFF
--- a/TwitterFriends/findfriends/templates/findfriends/index.html
+++ b/TwitterFriends/findfriends/templates/findfriends/index.html
@@ -17,7 +17,8 @@
 <script src="https://d3js.org/d3.v4.min.js"></script>
 <script>
 
-var data = {{ netjson|safe}}
+  var root = JSON.parse('{{ netjson|safe}}');
+  console.log(root)
 
 var svg = d3.select("svg"),
     width = +svg.attr("width"),
@@ -30,20 +31,17 @@ var simulation = d3.forceSimulation()
     .force("charge", d3.forceManyBody())
     .force("center", d3.forceCenter(width / 2, height / 2));
 
-d3.json( data , function(error, graph) {
-  if (error) throw error;
-
   var link = svg.append("g")
       .attr("class", "links")
     .selectAll("line")
-    .data(graph.links)
+    .data(root.links)
     .enter().append("line")
       .attr("stroke-width", function(d) { return Math.sqrt(d.value); });
 
   var node = svg.append("g")
       .attr("class", "nodes")
     .selectAll("circle")
-    .data(graph.nodes)
+    .data(root.nodes)
     .enter().append("circle")
       .attr("r", 5)
       .attr("fill", function(d) { return color(d.group); })
@@ -56,11 +54,11 @@ d3.json( data , function(error, graph) {
       .text(function(d) { return d.id; });
 
   simulation
-      .nodes(graph.nodes)
+      .nodes(root.nodes)
       .on("tick", ticked);
 
   simulation.force("link")
-      .links(graph.links);
+      .links(root.links);
 
   function ticked() {
     link
@@ -73,7 +71,6 @@ d3.json( data , function(error, graph) {
         .attr("cx", function(d) { return d.x; })
         .attr("cy", function(d) { return d.y; });
   }
-});
 
 function dragstarted(d) {
   if (!d3.event.active) simulation.alphaTarget(0.3).restart();

--- a/TwitterFriends/findfriends/templates/findfriends/index.html
+++ b/TwitterFriends/findfriends/templates/findfriends/index.html
@@ -17,6 +17,8 @@
 <script src="https://d3js.org/d3.v4.min.js"></script>
 <script>
 
+var data = {{ netjson|safe}}
+
 var svg = d3.select("svg"),
     width = +svg.attr("width"),
     height = +svg.attr("height");
@@ -28,7 +30,7 @@ var simulation = d3.forceSimulation()
     .force("charge", d3.forceManyBody())
     .force("center", d3.forceCenter(width / 2, height / 2));
 
-d3.json({{ netjson }}, function(error, graph) {
+d3.json( data , function(error, graph) {
   if (error) throw error;
 
   var link = svg.append("g")


### PR DESCRIPTION
By default django autoescape elements in template, so the json data must be marked as safe. 

Also you were trying to use d3js calling a url but you were passing data directly. Now it seems to work but maybe in a future instead of  sending data directly you may want to create a url to fetch json data and use d3js's json function. 

To use it passing data directly you must create a root var with the relations data.