### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.10.5
 oauthlib==2.0.1
-pkg-resources==0.0.0
 requests==2.12.4
 requests-oauthlib==0.7.0
 six==1.10.0


### PR DESCRIPTION
Remove troublemaking pkg-resources
Installation of  current requirements.txt fails:
```bash
 Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 3)) (from versions: )
No matching distribution found for pkg-resources==0.0.0 (from -r requirements.txt (line 3))
``` 
see https://github.com/pypa/pip/issues/4022
this pull request closes https://github.com/mgmacias95/TwitterFriends/issues/7